### PR TITLE
header UI追加

### DIFF
--- a/components/layouts/header.tsx
+++ b/components/layouts/header.tsx
@@ -29,6 +29,7 @@ import {
   useScroll,
   useMotionValueEvent,
   Image,
+  Flex,
 } from "@yamada-ui/react"
 import Link from "next/link"
 import type { FC } from "react"
@@ -92,6 +93,7 @@ export const Header: FC<HeaderProps> = ({ ...rest }) => {
             _light={{ display: "none" }}
           />
         </Box>
+        <NavMenu />
         <Spacer />
         <HStack>
           <ThemeSchemeButton />
@@ -106,6 +108,24 @@ type ColorModeButtonProps = IconButtonProps & {
   menuProps?: MenuProps
 }
 
+const NavMenu = () => {
+  // TODO: ページに応じてリンクを変更
+  const linkList = [
+    { href: "/", label: "記事一覧" },
+    { href: "/", label: "タグ" },
+    { href: "/", label: "コントリビュータ" },
+    { href: "/", label: "About" },
+  ]
+  return (
+    <Flex mx={6}>
+      {linkList.map((link) => (
+        <Box p="md" key={link.href}>
+          <Link href={link.href}>{link.label}</Link>
+        </Box>
+      ))}
+    </Flex>
+  )
+}
 const ColorModeButton: FC<ColorModeButtonProps> = memo(
   ({ menuProps, ...rest }) => {
     const { colorMode, internalColorMode, changeColorMode } = useColorMode()

--- a/components/layouts/header.tsx
+++ b/components/layouts/header.tsx
@@ -93,7 +93,6 @@ export const Header: FC<HeaderProps> = ({ ...rest }) => {
           />
         </Box>
         <Spacer />
-
         <HStack>
           <ThemeSchemeButton />
           <ColorModeButton />


### PR DESCRIPTION
Closes # <!-- 関連するイシュー番号があれば書く（例：#0） -->

## 概要

トップページの作成
簡易headerの追加
## 変更点
カラーテーマダークテーマ変更用ボタン追加
ナビゲーションリンク追加
<img width="961" alt="スクリーンショット 2024-09-14 15 20 59" src="https://github.com/user-attachments/assets/133f222d-5068-4401-a754-6faed13f99bc">

<!-- このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。 -->

## 追加情報

<!-- その他で記述する情報があれば書いてください -->
