### PR TITLE
chore: set timeout

### DIFF
--- a/.github/workflows/update-search-and-contributors.yml
+++ b/.github/workflows/update-search-and-contributors.yml
@@ -41,6 +41,7 @@ jobs:
           pnpm install
 
       - name: Run update script
+        timeout-minutes: 2
         run: |
           pnpm gen:search
           pnpm gen:contributors


### PR DESCRIPTION
## 概要
403でループし続けて429になっているワークフローにタイムアウトを追加。
https://github.com/illionillion/oss-blog/actions/runs/10886376629

GitHub actionsのusage limitsにあたってワークフローがキャンセルされているので暫定的な対応です。
あと無料枠溶けるのでご注意を。
https://docs.github.com/en/actions/administering-github-actions/usage-limits-billing-and-administration#usage-limits
https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#about-billing-for-github-actions

## 変更点
`jobs.update.Run update script`ステップにのみ設定しました。
履歴を見ると`30s`ほどで終了しているので、余裕を持って`2m`が妥当だと判断しました。

refs: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstepstimeout-minutes

<!-- その他で記述する情報があれば書いてください -->
